### PR TITLE
Fix Fear no Evil credit amount

### DIFF
--- a/sql/updates/world/world_2025_06_18_00.sql
+++ b/sql/updates/world/world_2025_06_18_00.sql
@@ -1,0 +1,6 @@
+-- Remove spellscript for Fear no Evil quest, as this is handled by the DBC
+DELETE FROM `spell_script_names` WHERE `spell_id` = 93072;
+
+-- Set the kill credit to 1 instead of 2 when casting 93072 on Injured Stormwind Soldier
+DELETE FROM `smart_scripts` WHERE `entryorguid`=5004700 AND `source_type`=9 AND `id`=0 AND `link`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES (5004700, 9, 0, 0, 0, 0, 100, 0, 500, 500, 0, 0, 33, 50047, 1, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Injured Stormwind Infantry - On Script - Quest Credit');

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2236,46 +2236,6 @@ enum FearNoEvil
     NPC_INJURED_STORMWIND_INFANTRY = 50047
 };
 
-// 93072 - Get Our Boys Back Dummy
-class spell_q28813_get_our_boys_back_dummy : public SpellScriptLoader
-{
-public:
-    spell_q28813_get_our_boys_back_dummy() : SpellScriptLoader("spell_q28813_get_our_boys_back_dummy") { }
-
-    class spell_q28813_get_our_boys_back_dummy_SpellScript : public SpellScript
-    {
-        PrepareSpellScript(spell_q28813_get_our_boys_back_dummy_SpellScript);
-
-        bool Validate(SpellInfo const* /*spellInfo*/) override
-        {
-            if (!sSpellMgr->GetSpellInfo(SPELL_RENEWED_LIFE))
-                return false;
-            return true;
-        }
-
-        void HandleDummyEffect()
-        {
-            Unit* caster = GetCaster();
-
-            if (Creature* injuredStormwindInfantry = caster->FindNearestCreature(NPC_INJURED_STORMWIND_INFANTRY, 5.0f, true))
-            {
-                injuredStormwindInfantry->SetCreatorGUID(caster->GetGUID());
-                injuredStormwindInfantry->CastSpell(injuredStormwindInfantry, SPELL_RENEWED_LIFE, true);
-            }
-        }
-
-        void Register() override
-        {
-            OnCast += SpellCastFn(spell_q28813_get_our_boys_back_dummy_SpellScript::HandleDummyEffect);
-        }
-    };
-
-    SpellScript* GetSpellScript() const override
-    {
-        return new spell_q28813_get_our_boys_back_dummy_SpellScript();
-    }
-};
-
 // 108897 - Pandaren Faction Choice
 class spell_q31450 : public SpellScript
 {
@@ -2513,7 +2473,6 @@ void AddSC_quest_spell_scripts()
     new spell_q12619_emblazon_runeblade_effect();
     new spell_q12919_gymers_grab();
     new spell_q12919_gymers_throw();
-    new spell_q28813_get_our_boys_back_dummy();
     new spell_script<spell_q31450>("spell_q31450");
     new spell_script<spell_q32683_q32726_ghostly_skeleton_key>("spell_q32683_q32726_ghostly_skeleton_key");
     new spell_script<spell_q12414_hand_over_reins>("spell_q12414_hand_over_reins");


### PR DESCRIPTION
Fixes the credit amount from 2 to 1, which is blizzlike
![bild](https://github.com/user-attachments/assets/3fe56858-0633-41c2-bdad-f888ff192e87)
